### PR TITLE
Export `crate::error::Error` and derive `Error` for it

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{error::Error as StdError, fmt};
 
 #[derive(Debug)]
 pub enum Error {
@@ -31,6 +31,8 @@ pub enum Error {
     InvalidFloat,
     ExpectBinOpToken,
 }
+
+impl StdError for Error {}
 
 #[cfg(not(tarpaulin_include))]
 impl fmt::Display for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,8 @@ mod descriptor;
 mod init;
 use std::sync::Arc;
 
+pub use error::Error;
+
 /// ## Usage
 ///
 /// Calling the engine is simple. At first, define the expression you want to execute. Secondly, create a context to cache the pre-defined inner functions and variables. And then, register the variables and functions to the context. Finally, call the execute function with  the expression and context to get the executing result.


### PR DESCRIPTION
The error type from this crate is impossible for downstream crates to use effectively, since it is both private and doesn't implement the `Error` trait. This PR fixes both of those issues, allowing downstream users to bubble `expression_engine::Error` in their [`thiserror`](https://crates.io/crates/anyhow) impls, and to return it simply using [`anyhow`](https://crates.io/crates/anyhow)