### PR TITLE
Derive `Clone` on `Context`

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -11,6 +11,7 @@ pub enum ContextValue {
     Function(Arc<InnerFunction>),
 }
 
+#[derive(Clone)]
 pub struct Context(pub Arc<Mutex<HashMap<String, ContextValue>>>);
 
 impl Context {


### PR DESCRIPTION
The `Context` API is great, but currently it's annoying to reuse across multiple expressions, since the context can't be cloned. Deriving `Clone` makes fixes this issue and makes it easier to use. 