### PR TITLE
Export `ContextValue`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,7 @@ fn init() {
 
 pub type Value = value::Value;
 pub type Context = context::Context;
+pub type ContextValue = context::ContextValue;
 pub type Result<T> = define::Result<T>;
 pub type ExprAST<'a> = parser::ExprAST<'a>;
 pub type InfixOpType = operator::InfixOpType;


### PR DESCRIPTION
Currently `ContextValue` is private. This is fine in most cases, but I recently ran into a case where I wanted to iterate over the values in my context for error reporting, but you can't match variable values from the `ContextValue`s because, it is private. This PR adds an export for it.