### PR TITLE
⚡ Bolt: [performance improvement] optimize Value enum Display allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-26 - Optimize decimal conversion in Value
 **Learning:** `rust_decimal::Decimal` allows efficient and direct conversion to basic types like `i64` and `f64` via `to_i64` and `to_f64` using the `rust_decimal::prelude::ToPrimitive` trait. Converting to string and then parsing `val.to_string().parse()` is an anti-pattern as it incurs heap allocation overhead, which is bad for performance. When doing integer conversions from `Decimal`, it's critical to check `val.scale() == 0` first to maintain behavioral parity with string parsing (which would reject floats).
 **Action:** Always favor direct conversion traits like `rust_decimal::prelude::ToPrimitive` methods over stringification when converting `Decimal` values to native numeric types. Keep edge cases like `scale()` properties in mind when changing conversion methods.
+
+## 2024-05-27 - Avoid intermediate strings and clones in std::fmt::Display
+**Learning:** For `std::fmt::Display` implementations involving collections (like Lists or Maps), building an intermediate `String` via `format!()` and `push_str()` before writing it causes unnecessary heap allocations and redundant data cloning.
+**Action:** Write directly to the `std::fmt::Formatter` using `write!(f, ...)` to stream characters without allocating extra memory, and remove unnecessary `.clone()` calls during formatting.

--- a/src/value.rs
+++ b/src/value.rs
@@ -17,25 +17,22 @@ pub enum Value {
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::String(val) => write!(f, "value string: {}", val.clone()),
-            Self::Number(val) => write!(f, "value number: {}", val.clone()),
-            Self::Bool(val) => write!(f, "value bool: {}", val.clone()),
+            Self::String(val) => write!(f, "value string: {}", val),
+            Self::Number(val) => write!(f, "value number: {}", val),
+            Self::Bool(val) => write!(f, "value bool: {}", val),
             Self::List(values) => {
-                let mut s = String::from("[");
+                write!(f, "value list: [")?;
                 for value in values {
-                    s.push_str(format!("{},", value.clone()).as_str());
+                    write!(f, "{},", value)?;
                 }
-                s.push_str("]");
-                write!(f, "value list: {}", s)
+                write!(f, "]")
             }
             Self::Map(m) => {
-                let mut s = String::from("{");
+                write!(f, "value map: {{")?;
                 for (k, v) in m {
-                    s.push_str(format!("key: {},", k.clone()).as_str());
-                    s.push_str(format!("value: {}; ", v.clone()).as_str());
+                    write!(f, "key: {},value: {}; ", k, v)?;
                 }
-                s.push_str("}");
-                write!(f, "value map: {}", s)
+                write!(f, "}}")
             }
             Self::None => write!(f, "None"),
         }


### PR DESCRIPTION
💡 **What**: Optimized the `std::fmt::Display` implementation for the `Value` enum by writing directly to the `std::fmt::Formatter` stream. This removed intermediate `String` creations (using `format!()` and `String::from()`) and eliminated redundant `.clone()` operations.

🎯 **Why**: Generating temporary string buffers and repeatedly cloning inner values adds unnecessary heap allocations and overhead when formatting large collections like `Value::List` and `Value::Map`. Directly writing to the formatter stream is more idiomatic and performant in Rust.

📊 **Impact**: Reduces peak memory usage and avoids unneeded heap allocations during stringification of expressions. Lowers the overhead of executing display and logging functionalities involving the `Value` type.

🔬 **Measurement**: Execute `cargo bench` and observe the reduction in memory pressure or the slight improvement in average throughput when repeatedly evaluating expressions containing lists and maps. Verify original format functionality using `cargo test`.

---
*PR created automatically by Jules for task [2694804711574819080](https://jules.google.com/task/2694804711574819080) started by @ashyanSpada*